### PR TITLE
Add mistune to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ jdcal==1.3
 Jinja2==2.8
 lxml==3.5.0
 MarkupSafe==0.23
+mistune==0.8.4
 normality==0.2.4
 openpyxl==2.4.7
 python-dateutil==2.7.3


### PR DESCRIPTION
Setting up from scratch, I get:

```
$ python manage.py runserver
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    import maediprojects
  File "liberia-projects/maediprojects/__init__.py", line 7, in <module>
    import mistune
ImportError: No module named mistune
```

This fixes that.